### PR TITLE
Fix closure serialization issue on request matcher.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "license": "Apache-2.0",
     "require": {
         "guzzlehttp/psr7": "~1.0",
+        "jeremeamia/superclosure": "^2.4",
         "php-http/client-common": "^1.9",
         "php-http/httplug": "^1.1",
         "psr/http-message": "^1.0"

--- a/src/MockStoragePropertyTrait.php
+++ b/src/MockStoragePropertyTrait.php
@@ -21,6 +21,7 @@ namespace Apigee\MockClient;
 use Apigee\MockClient\Psr7\SerializableMessageWrapper;
 use Http\Message\RequestMatcher;
 use Psr\Http\Message\ResponseInterface;
+use SuperClosure\SerializableClosure;
 
 /**
  * A trait for dealing with the mock storage property.
@@ -50,14 +51,15 @@ trait MockStoragePropertyTrait {
     if ($result instanceof \Exception || $result instanceof ResponseInterface || is_callable($result)) {
       // Some storage provides will try to serialize the result.
       $result = $result instanceof ResponseInterface ? new SerializableMessageWrapper($result) : $result;
+
       // Normalize to a callable result.
-      $callable = is_callable($result) ? $result : function () use ($result) {
+      $callable = is_callable($result) ? $result : new SerializableClosure(function () use ($result) {
         if ($result instanceof \Exception) {
           throw $result;
         }
         // The only other available type for $result is `SerializableMessageWrapper`.
         return $result->getMessage();
-      };
+      });
 
       $this->storage->addMatchableResult(new MatchableResult($requestMatcher, $callable));
     } else {


### PR DESCRIPTION
When using the request matcher and a database storage provider, a closure is trying to be serialized and failing because closures in PHP aren't serializable (`Exception: Serialization of 'Closure' is not allowed`).
This PR uses the [SuperClosure library](https://github.com/jeremeamia/super_closure) to provide a serializable wrapper around the closure and solve that issue.