### PR TITLE
Fix for kernel test for Drupal 10

### DIFF
--- a/src/Generator/TwigGenerator.php
+++ b/src/Generator/TwigGenerator.php
@@ -29,7 +29,7 @@ class TwigGenerator implements ResponseGeneratorInterface {
   /**
    * The twig environment.
    *
-   * @var \Twig_Environment
+   * @var \Twig\Environment
    */
   protected $twig;
 
@@ -38,7 +38,7 @@ class TwigGenerator implements ResponseGeneratorInterface {
    *
    * @param \Twig_Environment $twig
    */
-  public function __construct(\Twig_Environment $twig) {
+  public function __construct(\Twig\Environment $twig) {
     $this->twig = $twig;
   }
 

--- a/src/Psr7/SerializableMessageWrapper.php
+++ b/src/Psr7/SerializableMessageWrapper.php
@@ -19,7 +19,7 @@
 namespace Apigee\MockClient\Psr7;
 
 use Psr\Http\Message\MessageInterface;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 
 /**
  * The serializable HTTP message wrapper.
@@ -81,7 +81,7 @@ class SerializableMessageWrapper {
    */
   public function __wakeup() {
     // Restore the response with the original body.
-    $this->message = $this->message->withBody(stream_for($this->body));
+    $this->message = $this->message->withBody(Utils::streamFor($this->body));
 
     unset($this->body);
   }


### PR DESCRIPTION
Fixes #8 
This PR will fix below errors
1. "Call to undefined function GuzzleHttp\Psr7\stream_for()
2. TypeError: Apigee\MockClient\Generator\TwigGenerator::__construct(): Argument # 1 ($twig) must be of type Twig_Environment, Twig\Environment given